### PR TITLE
[Add] incident beam monitor normalization

### DIFF
--- a/src/ess/spectroscopy/indirect/ki.py
+++ b/src/ess/spectroscopy/indirect/ki.py
@@ -14,6 +14,7 @@ from ess.spectroscopy.types import (
     FocusComponentNames,
     IncidentDirection,
     IncidentEnergy,
+    IncidentSloth,
     IncidentSlowness,
     IncidentWavelength,
     IncidentWavenumber,
@@ -119,10 +120,8 @@ def guess_focus_component_names(file: NeXusFileName) -> FocusComponentNames:
         The name or names of the time-focus-defining choppers, given the restrictions
         noted above
     """
-    from scipp import scalar
+    from scipp import norm, scalar
     from scippnexus import File, NXdisk_chopper, compute_positions
-
-    from ..utils import norm
 
     allowance = scalar(0.5, unit='m')
 
@@ -193,9 +192,8 @@ def focus_distance(
         The average straight-line distance from the source position to the named
         component(s)
     """
+    from scipp import norm
     from scippnexus import File, compute_positions
-
-    from ..utils import norm
 
     pos = 0 * origin
     with File(file) as data:
@@ -363,6 +361,18 @@ def incident_slowness(
     return slowness
 
 
+def incident_sloth(
+    primary: PrimarySpectrometerObject, slowness: IncidentSlowness
+) -> IncidentSloth:
+    from choppera.nexus import primary_slowness
+    from scipp import max, min
+
+    from ..utils import in_same_unit
+
+    min_max = in_same_unit(primary_slowness(primary), to=slowness)
+    return (slowness - min(min_max)) / (max(min_max) - min(min_max))
+
+
 def incident_wavelength(slowness: IncidentSlowness) -> IncidentWavelength:
     """Calculate the incident wavelength from the incident slowness for each neutron"""
     from scipp.constants import Planck, neutron_mass
@@ -412,6 +422,7 @@ providers = (
     unwrap_sample_time,
     incident_direction,
     incident_slowness,
+    incident_sloth,
     incident_wavelength,
     incident_wavenumber,
     incident_wavevector,

--- a/src/ess/spectroscopy/indirect/ki.py
+++ b/src/ess/spectroscopy/indirect/ki.py
@@ -364,13 +364,13 @@ def incident_slowness(
 def incident_sloth(
     primary: PrimarySpectrometerObject, slowness: IncidentSlowness
 ) -> IncidentSloth:
+    import scipp as sc
     from choppera.nexus import primary_slowness
-    from scipp import max, min
 
-    from ..utils import in_same_unit
+    from ..utils import range_normalized
 
-    min_max = in_same_unit(primary_slowness(primary), to=slowness)
-    return (slowness - min(min_max)) / (max(min_max) - min(min_max))
+    min_max = primary_slowness(primary)
+    return range_normalized(slowness, sc.min(min_max), sc.max(min_max))
 
 
 def incident_wavelength(slowness: IncidentSlowness) -> IncidentWavelength:

--- a/src/ess/spectroscopy/indirect/normalisation.py
+++ b/src/ess/spectroscopy/indirect/normalisation.py
@@ -6,15 +6,24 @@ from scipp import DataArray
 from ..types import (
     FrameTimeMonitor,
     IncidentSlowness,
+    MonitorName,
     MonitorNormalisation,
+    MonitorPosition,
+    NeXusFileName,
+    NormWavelengthEvents,
     PrimaryFocusDistance,
     PrimaryFocusTime,
     PrimarySpectrometerObject,
+    SlothMonitor,
     SlownessMonitor,
     SourceFrequency,
     SourceMonitorFlightTime,
     SourceMonitorPathLength,
+    SourcePosition,
     WallTimeMonitor,
+    WavelengthBins,
+    WavelengthEvents,
+    WavelengthMonitor,
 )
 
 
@@ -28,6 +37,51 @@ def incident_monitor_normalization(
     if len(coords) != 1:
         raise ValueError(f'Monitor expected to have exactly 1 coordinate, has {coords}')
     return lookup(monitor, dim=coords[0])[slowness]
+
+
+def monitor_position(file: NeXusFileName, monitor: MonitorName) -> MonitorPosition:
+    """Extract the position of the named monitor from a NeXus file"""
+    from scippnexus import File, compute_positions
+
+    with File(file) as data:
+        return compute_positions(data['entry/instrument'][monitor][...])['position']
+
+
+def source_monitor_path_length(
+    file: NeXusFileName, source: SourcePosition, monitor: MonitorPosition
+) -> SourceMonitorPathLength:
+    """Compute the primary spectrometer path length from source to monitor positions
+
+    Note:
+        This *requires* that the instrument group *is sorted* along the beam path.
+        HDF5 group entries are sorted alphabetically, so you should ensure that
+        the NeXus file was constructed with this in mind.
+    """
+    from scipp import concat, dot, sqrt, sum
+    from scippnexus import File, NXguide, compute_positions
+
+    with File(file) as data:
+        positions = [
+            compute_positions(v[...])['position']
+            for v in data['entry/instrument'][NXguide].values()
+        ]
+
+    def vector_length(vector):
+        return sqrt(dot(vector, vector))
+
+    # Find the closest guide to the monitor position, ignoring the possibility that
+    # a guide could be _beyond_ the monitor _and_ closest :(
+    closest = 0
+    distance = vector_length(source - monitor)
+    for i, position in enumerate(positions):
+        d = vector_length(position - monitor)
+        if d < distance:
+            distance = d
+            closest = i
+
+    positions = concat((source, *positions[:closest], monitor), dim='path')
+    diff = positions['path', 1:] - positions['path', :-1]
+    return sum(vector_length(diff))
 
 
 def monitor_pivot_time(
@@ -63,18 +117,22 @@ def monitor_wall_time(
         The same intensities with independent axis converted to the likely time since
         neutron-producing proton pulse
     """
-    from choppera.nexus import unwrap
+    from choppera.nexus import unwrap, unwrap_histogram
 
-    coords = list(monitor.coords)
-    if len(coords) != 1:
-        raise ValueError(f'Monitor expected to have exactly 1 coordinate, has {coords}')
-    frame = coords[0]
+    frame = 'frame_time'
+    if frame not in monitor.coords:
+        raise RuntimeError(f'A FrameTimeMonitor must have coordinate "{frame}"')
     wall = 'wall_time'
     names = {frame: wall}
-    return DataArray(
-        monitor.data.rename(names),
-        coords={wall: unwrap(monitor.coords[frame], frequency, least).rename(names)},
-    )
+    if monitor.sizes[frame] + 1 == monitor.coords[frame].size:
+        coord, values = unwrap_histogram(
+            monitor.coords[frame], monitor.data, frequency, least
+        )
+    else:
+        values = monitor.data
+        coord = unwrap(monitor.coord[frame], frequency, least)
+
+    return DataArray(values.rename(names), coords={wall: coord.rename(names)})
 
 
 def monitor_slowness(
@@ -105,18 +163,131 @@ def monitor_slowness(
         The same intensities with independent axis converted to the inverse velocity
         of the neutrons, which scales linearly with wall time
     """
-    coords = list(monitor.coords)
-    if len(coords) != 1:
-        raise ValueError(f'Monitor expected to have exactly 1 coordinate, has {coords}')
-    wall = coords[0]
+    from ..utils import in_same_unit
+
+    wall = 'wall_time'
+    if wall not in monitor.coords:
+        raise RuntimeError(f'A WallTimeMonitor must have coordinate "{wall}"')
     slow = 'slowness'
     names = {wall: slow}
-    slowness = (
-        ((monitor.coords[wall] - focus) / (length - distance))
-        .rename(names)
-        .to(unit='s/m')
-    )
+    wall_time = monitor.coords[wall]
+    duration = wall_time - in_same_unit(focus, to=wall_time)
+    slowness = (duration / (length - distance)).rename(names).to(unit='s/m')
     return DataArray(monitor.data.rename(names), coords={slow: slowness})
+
+
+def monitor_wavelength(monitor: SlownessMonitor) -> WavelengthMonitor:
+    """Convert the independent 'slowness' coordinate of a histogram DataArray to the
+    equivalent wavelength
+
+    Parameters
+    ----------
+    monitor:
+        A histogram beam monitor which has been converted from recorded 'frame time'
+        to inverse neutron velocity
+
+    Returns
+    -------
+    :
+        The same intensities with independent axis converted to wavelength
+    """
+    from scipp.constants import Planck, neutron_mass
+
+    c = Planck / neutron_mass
+    slow = 'slowness'
+    # wavelength = 'incident_wavelength'
+    if slow not in monitor.coords:
+        raise RuntimeError(f'A SlownessMonitor must have the coordinate "{slow}"')
+
+    def converter(slowness):
+        return (c * slowness).to(unit='angstrom')
+
+    # names = {slow: wavelength}
+    converted = monitor.transform_coords(incident_wavelength=converter)
+    return converted
+
+
+def monitor_sloth(
+    primary: PrimarySpectrometerObject, monitor: SlownessMonitor
+) -> SlothMonitor:
+    """Convert the independent 'slowness' coordinate of a histogram DataArray to the
+    equivalent sloth, which is -- equivalently -- normalised slowness, normalised
+    inverse velocity, or normalised (incident) wavelength
+
+    Parameters
+    ----------
+    primary:
+        The primary spectrometer object describing the choppers and guide setting(s)
+    monitor:
+        A histogram beam monitor which has been converted from recorded 'frame time' to
+        inverse neutron velocity
+
+    Returns
+    -------
+    :
+        The same intensities with independent axis converted to the sloth,
+        which is the normalised slowness, inverse velocity, and incident wavelength
+    """
+    from choppera.nexus import primary_slowness
+    from scipp import max, min
+
+    from ..utils import in_same_unit
+
+    slow = 'slowness'
+    if slow not in monitor.coords:
+        raise RuntimeError(f'A SlownessMonitor must have the coordinate "{slow}"')
+    sloth = 'sloth'
+    names = {slow: sloth}
+    min_max = in_same_unit(primary_slowness(primary), to=monitor.coords[slow])
+    normed = (
+        (monitor.coords[slow] - min(min_max)) / (max(min_max) - min(min_max))
+    ).rename(names)
+    return DataArray(monitor.data.rename(names), coords={sloth: normed})
+
+
+def normalise(
+    events: WavelengthEvents,
+    monitor: WavelengthMonitor,
+    edges: WavelengthBins,
+) -> NormWavelengthEvents:
+    """Ensure the WavelengthEvents are binned according to the WavelengthBins, then use
+    the WavelengthMonitor as a lookup table to record the per-bin normalization.
+
+    Parameters
+    ----------
+    events
+        Event data which includes a per-event sloth coordinate
+    monitor
+        (Probably) 1-D histogram data with a sloth coordinate
+    edges
+        1-D bin boundaries for the event data
+
+    Returns
+    -------
+    :
+        Event data binned by sloth, with a coordinate that is the per-bin normalization
+    """
+    from scipp import lookup
+
+    dim = 'incident_wavelength'
+    centres = (edges[:-1] + edges[1:]) / 2
+    variances = None
+    if monitor.variances is not None:
+        monitor = monitor.copy()
+        variances = monitor.copy()
+        variances.values = monitor.variances
+        monitor.variances = None
+        variances.variances = None
+    counts = lookup(monitor, dim)[centres]
+    if variances is not None:
+        # Bad form, maybe. But two events with the same sloth bin are normalized
+        # by the same monitor counts -- which has a known uncertainty -- and scipp
+        # refuses to allow lookup on data which has variances defined.
+        counts.variances = (lookup(variances, dim)[centres]).values
+
+    binned = events.bin(**{dim: edges})
+    binned.coords['monitor'] = counts
+    return binned
 
 
 providers = (
@@ -124,4 +295,9 @@ providers = (
     monitor_pivot_time,
     monitor_wall_time,
     monitor_slowness,
+    monitor_wavelength,
+    monitor_sloth,
+    monitor_position,
+    source_monitor_path_length,
+    normalise,
 )

--- a/src/ess/spectroscopy/indirect/workflow.py
+++ b/src/ess/spectroscopy/indirect/workflow.py
@@ -526,8 +526,6 @@ def add_wavelength_axes(ki_params, kf_params, events, monitor, monitor_name):
     params.update(ki_params)
     params.update(kf_params)
     pipeline = Pipeline(monitor_providers + ki_providers + kf_providers, params=params)
-    # slowness = pipeline.compute(SlownessMonitor)
-    # pipeline[SlownessMonitor] = slowness
     wavelength_monitor = pipeline.compute(WavelengthMonitor)
     events.bins.coords['incident_wavelength'] = pipeline.compute(IncidentWavelength)
     return events, wavelength_monitor
@@ -719,7 +717,6 @@ def one_setting(
     )
     ei, en, ef = get_energy_axes(ki_params, kf_params)
 
-    # energy_events = sample_events.copy()
     events.bins.coords['energy_transfer'] = en.to(unit='meV')
     events.bins.coords['incident_energy'] = ei
     events.coords['final_energy'] = ef

--- a/src/ess/spectroscopy/indirect/workflow.py
+++ b/src/ess/spectroscopy/indirect/workflow.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from loguru import logger
 from scipp import Variable
 
-from ..types import NeXusFileName
+from ..types import NeXusFileName, NormWavelengthEvents
 
 
 def _load_all(group, obj_type):
@@ -335,6 +335,8 @@ def get_unwrapped_events(
     }
     pipeline = Pipeline(ki_providers, params=params)
     primary = pipeline.get(PrimarySpectrometerObject).compute()
+    pipeline[PrimarySpectrometerObject] = primary
+    params[PrimarySpectrometerObject] = primary
 
     events = sample_events.copy()
     events.bins.coords['frame_time'] = pipeline.get(SampleTime).compute()
@@ -474,6 +476,83 @@ def add_momentum_axes(ki_params, kf_params, events, a3: Variable):
     events.bins.coords['table_momentum_z'] = (
         pipeline.get(TableMomentumTransferZ).compute().transpose(events.dims)
     )
+    return events
+
+
+def add_wavelength_axes(ki_params, kf_params, events, monitor, monitor_name):
+    """Convert to incident wavelength per event and independent monitor axis
+
+    Parameters
+    ----------
+    ki_params:
+        A dictionary of parameters needed by the incident-spectrometer sciline pipeline
+    kf_params:
+        A dictionary of parameters needed by the secondary-spectrometer sciline pipeline
+    events:
+        Event data, presumably with per-event incident energy (or wavelength, or
+        inverse velocity == slowness) already calculated; the basis for the returned
+        events
+    monitor:
+        A beam monitor with one independent axis (time since last pulse as measured).
+        The monitor intensity is expected to be a histogram along the one independent
+        axis, but event monitor data should work as well.
+    monitor_name:
+        The name of the provided beam monitor, used to get its position in the
+        primary spectrometer
+
+    Returns
+    -------
+    :
+        The events with a new coordinate, 'incident_wavelength'.
+        And the monitor with 'incident_wavelength' coordinate.
+    """
+    from sciline import Pipeline
+
+    from ..types import (
+        FrameTimeMonitor,
+        # SlownessMonitor,
+        IncidentWavelength,
+        MonitorName,
+        WavelengthMonitor,
+    )
+    from .kf import providers as kf_providers
+    from .ki import providers as ki_providers
+    from .normalisation import providers as monitor_providers
+
+    params = {
+        MonitorName: monitor_name,
+        FrameTimeMonitor: monitor,
+    }
+    params.update(ki_params)
+    params.update(kf_params)
+    pipeline = Pipeline(monitor_providers + ki_providers + kf_providers, params=params)
+    # slowness = pipeline.compute(SlownessMonitor)
+    # pipeline[SlownessMonitor] = slowness
+    wavelength_monitor = pipeline.compute(WavelengthMonitor)
+    events.bins.coords['incident_wavelength'] = pipeline.compute(IncidentWavelength)
+    return events, wavelength_monitor
+
+
+def normalise_wavelength_events(ki_params, kf_params, events, monitor):
+    from sciline import Pipeline
+
+    from ..types import (
+        NormWavelengthEvents,
+        WavelengthBins,
+        WavelengthEvents,
+        WavelengthMonitor,
+    )
+    from .normalisation import providers
+
+    params = {
+        WavelengthEvents: events,
+        WavelengthMonitor: monitor,
+        WavelengthBins: monitor.coords['incident_wavelength'],
+    }
+    params.update(ki_params)
+    params.update(kf_params)
+    pipeline = Pipeline(providers, params=params)
+    events = pipeline.compute(NormWavelengthEvents)
     return events
 
 
@@ -635,16 +714,16 @@ def one_setting(
     kf_params, sample_detector_flight_time = find_sample_detector_flight_time(
         sample, analyzers, detector_positions
     )
-    sample_events = get_sample_events(triplet_events, sample_detector_flight_time)
+    events = get_sample_events(triplet_events, sample_detector_flight_time)
     ki_params, unwrapped_events, primary = get_unwrapped_events(
-        filename, names['source'], names['sample'], sample_events, names['focus']
+        filename, names['source'], names['sample'], events, names['focus']
     )
     ei, en, ef = get_energy_axes(ki_params, kf_params)
 
-    energy_events = sample_events.copy()
-    energy_events.bins.coords['energy_transfer'] = en.to(unit='meV')
-    energy_events.bins.coords['incident_energy'] = ei
-    energy_events.coords['final_energy'] = ef
+    # energy_events = sample_events.copy()
+    events.bins.coords['energy_transfer'] = en.to(unit='meV')
+    events.bins.coords['incident_energy'] = ei
+    events.coords['final_energy'] = ef
 
     if 'a3' in triplet_events.coords:
         # this _should_ be one (a3, a4) setting,
@@ -657,20 +736,24 @@ def one_setting(
             logger.warning("No a3 present in setting, assuming 0 a3")
         a3 = scalar(0, unit='deg')
 
-    energy_momentum_events = add_momentum_axes(ki_params, kf_params, energy_events, a3)
+    events = add_momentum_axes(ki_params, kf_params, events, a3)
+
+    # Set up the normalisation by adding a 'incident_wavelength' coordinate to
+    # the individual events and the normalisation monitor
+    events, monitor = add_wavelength_axes(
+        ki_params, kf_params, events, norm_monitor, names['monitor']
+    )
+
+    norm_events = normalise_wavelength_events(ki_params, kf_params, events, monitor)
 
     return {
         'triplet_events': triplet_events,
-        'sample_events': sample_events,
-        'unwrapped_events': unwrapped_events,
+        'events': events,
         'norm_monitor': norm_monitor,
-        'energy_events': energy_events,
         'sample_detector_flight_time': sample_detector_flight_time,
         'analyzers': analyzers,
-        'energy_momentum_events': energy_momentum_events,
-        # 'detectors': detectors,
-        # 'monitors': monitors,
-        # 'triplets': triplets,
+        'wavelength_monitor': monitor,
+        'norm_events': norm_events,
     }
 
 
@@ -828,7 +911,7 @@ def bifrost(
     may not all be useful, and are subject to pruning as experience is gained with
     the workflow.
     """
-    import scipp as sc
+    from scipp import concat
     from tqdm import tqdm
 
     named_components = component_names(
@@ -855,7 +938,7 @@ def bifrost(
             settings, desc='(a3, a4) settings'
         )
     ]
-    return {k: sc.concat([d[k] for d in data], 'setting') for k in data[0]}
+    return {k: concat([d[k] for d in data], 'setting') for k in data[0]}
 
 
 def bifrost_single(
@@ -909,6 +992,8 @@ def bifrost_single(
     sample, analyzers, triplet_events, norm_monitor, logs = load_precompute(
         filename, named_components, is_simulated
     )
+    if 'time' in norm_monitor.sizes:
+        norm_monitor = norm_monitor.sum('time')
 
     data = one_setting(
         sample,

--- a/src/ess/spectroscopy/indirect/workflow.py
+++ b/src/ess/spectroscopy/indirect/workflow.py
@@ -537,7 +537,6 @@ def normalise_wavelength_events(ki_params, kf_params, events, monitor):
     from sciline import Pipeline
 
     from ..types import (
-        NormWavelengthEvents,
         WavelengthBins,
         WavelengthEvents,
         WavelengthMonitor,

--- a/src/ess/spectroscopy/types.py
+++ b/src/ess/spectroscopy/types.py
@@ -32,6 +32,7 @@ ReciprocalLatticeVectorAbsolute = variable_type('ReciprocalLatticeVectorAbsolute
 ReciprocalLatticeSpacing = variable_type('ReciprocalLatticeSpacing')
 IncidentDirection = variable_type('IncidentDirection')
 IncidentSlowness = variable_type('IncidentSlowness')
+IncidentSloth = variable_type('IncidentSloth')
 IncidentWavelength = variable_type('IncidentWavelength')
 IncidentWavenumber = variable_type('IncidentWavenumber')
 IncidentWavevector = variable_type('IncidentWavevector')
@@ -66,11 +67,15 @@ FocusComponentNames = NewType('FocusComponentNames', list[FocusComponentName])
 PrimaryFocusDistance = variable_type('PrimaryFocusDistance')
 PrimaryFocusTime = variable_type('PrimaryFocusTime')
 
+MonitorName = NewType('MonitorName', str)
+MonitorPosition = variable_type('MonitorPosition')
 SourceMonitorPathLength = variable_type('SourceMonitorPathLength')
 SourceMonitorFlightTime = variable_type('SourceMonitorFlightTime')
 FrameTimeMonitor = data_array_type('FrameTimeMonitor')
 WallTimeMonitor = data_array_type('WallTimeMonitor')
 SlownessMonitor = data_array_type('SlownessMonitor')
+WavelengthMonitor = data_array_type('WavelengthMonitor')
+SlothMonitor = data_array_type('SlothMonitor')
 
 MonitorNormalisation = variable_type('MonitorNormalisation')
 
@@ -92,5 +97,15 @@ SampleMomentumTransferZ = variable_type("SampleMomentumTransferZ")
 
 EnergyTransfer = variable_type('EnergyTransfer')
 
-# Debugging types, likely to be removed
 DetectorGeometricA4 = variable_type("DetectorGeometricA4")
+
+SlothEvents = data_array_type('SlothEvents')
+SlothBins = variable_type('SlothBins')
+NormSlothEvents = data_array_type('NormSlothEvents')
+
+WavelengthEvents = data_array_type('WavelengthEvents')
+WavelengthBins = variable_type('WavelengthBins')
+NormWavelengthEvents = data_array_type('NormWavelengthEvents')
+
+NXspeFileName = NewType('NXspeFileName', str)
+NXspeFileNames = NewType('NXspeFileNames', list[NXspeFileName])

--- a/src/ess/spectroscopy/utils.py
+++ b/src/ess/spectroscopy/utils.py
@@ -24,5 +24,27 @@ def in_same_unit(b: Variable, to: Variable | None = None) -> Variable:
     return b
 
 
+def range_normalized(variable: Variable, minimum: Variable, maximum: Variable):
+    """Convert a variable to a normalized range
+
+    Parameters
+    ----------
+    variable: scipp.Variable
+        The values to be normalized
+    minimum: scipp.Variable
+        The minimal value that the input `variable` could take
+    maximum: scipp.Variable
+        The maximal value that the input `variable` could take
+
+    Returns
+    -------
+    :
+        The input `variable` rescaled by the range of allowed values
+    """
+    full = maximum - minimum
+    minimum, full = (in_same_unit(x, to=variable) for x in (minimum, full))
+    return (variable - minimum) / full
+
+
 def is_in_coords(x: DataArray, name: str):
     return name in x.coords or (x.bins is not None and name in x.bins.coords)


### PR DESCRIPTION
In preparation for visualizing _S(**Q,** E)_ or saving to histogram data formats, like `NXspe`, it is necessary to normalize intensity by the incident beam monitor.

This adds the functionality to convert a histogram frame-time monitor's independent axis to wavelength (or normalized wavelength, 'sloth').

Other small changes have been made, such as combining workflow-output datasets that differed only in their coordinates -- with one having a subset of the other. This eliminates an event DataArray copy operation, improving workflow speed.