### PR TITLE
[Add] NXspe output and relegation ADR

### DIFF
--- a/docs/developer/adr/0001-relegate-nxspe-support.md
+++ b/docs/developer/adr/0001-relegate-nxspe-support.md
@@ -1,0 +1,107 @@
+# ADR 0001: Relagate NXspe support
+
+- Status:
+- Deciders:
+- Date: 2024-10
+
+## Context
+Targeting community supported data formats will enable efficient use of existing analysis and visualization tools.
+A number of histogram formats have been [listed for possible support](https://jira.ess.eu/browse/DMSCSPEC-46):
+- [`NXspe`](https://jira.ess.eu/browse/DMSCSPEC-50)
+- [`SQW`](https://jira.ess.eu/browse/DMSCSPEC-51)
+- [`MJOLNIR`](https://jira.ess.eu/browse/DMSCSPEC-52)
+
+### `SQW` Prioritization and Challenges
+
+One of which, [`SQW`](https://github.com/scipp/essspectroscopy/issues/23),
+has been identified as higher importance because it will enable interfacing with
+the PACE tools.
+
+The major drawback to the `SQW` format is that it is documented most thoroughly by
+its `MATLAB` serialization/deserialization routines, which are less than straightforward
+to replicate in part due to an extensive class hierarchy, single-source backwards
+compatibility over multiple file format versions, the ability to mix definition and
+implementation of functions and place either in at least three different locations
+(the `rundata` helper class seems to be spread over six),
+and the lack of a free IDE that can help sort out the runtime behavior.
+
+Recently it was posited that, since `Horace` can read `NXspe` files and produce a valid
+`SQW` file from them, perhaps focusing on their output from `essspectroscopy` could
+be prudent.
+
+### Bending `NXspe` to Indirect-Geometry Time-of-Flight
+`NXspe` is the [`NeXus` application definition](https://manual.nexusformat.org/classes/applications/NXspe.html#nxspe)
+implementation of the columns-of-text `SPE` data format.
+
+`SPE` format files contain energy-transfer (or time) histograms of intensity,
+one per detector element in the instrument.
+Information about the positions and sizes of the detector elements was contained in
+a separate file, either `PAR` or `PHX`.
+The format was defined with Direct-Geometry (DG) Time-of-Flight (TOF) spectrometers in
+mind where a single incident energy applied to all data, and all detector elements
+shared the same energy-transfer histogram bin edges. This information was kept
+separately from the two text files, and put into analysis scripts by the user.
+
+`NXspe` incorporates all information contained previously in `SPE` and `PAR` files
+plus minimal information that otherwise may have gone into a log book.
+It represents an appreciable improvement over the previous status-quo for DG-TOF.
+
+For Indirect-Geometry (IG) TOF instruments with a single final neutron energy, like
+back-scattering instruments, it is also possible to histogram all detector energy
+spectra with a single set of bin edges. By means of a flag, `Horace` can exchange
+_E_<sub>i</sub> and _E_<sub>f</sub> in early data loading calculations, and then
+otherwise treat conversion more-or-less the same to produce intensity of (**_Q_**,_E_)
+observations binned, not unlike `scipp`, in a coarse 4-D grid.
+
+The problems start, however, when not all detectors share a single final energy,
+as with BIFROST.
+A single incident wavelength range applies for all BIFROST detector elements,
+so one _E_<sub>i</sub> bin-boundary set would naturally apply for all detectors.
+But this is _far_ from fixed _E_<sub>i</sub> or fixed _E_<sub>f</sub> with a single
+energy transfer, _E_, bin-boundary set.
+
+#### Imaginary observations
+The closest BIFROST data can get to 'standard' `NXspe` _E_ binning is to stitch
+together the single _E_<sub>i</sub> ranges offset by each _E_<sub>f</sub>.
+This has three drawbacks
+1. The number of bins per detector element will consequently be larger
+2. The sizes of the bins may not match well to the 'natural' incident energy bin sizes for all detector elements
+3. Imaginary observations will be created for all detector elements.
+
+> **Note:**
+> The term imaginary is used here to indicate that no measurement was performed
+> for the incident neutron energies needed to produce the _E_ in one or more bin.
+
+#### Natural _E_ binning
+Instead, by keeping per-detector-element _E_ binning the adherence to
+the `NXspe` standard can be maintained but software like `Horace` struggle to handle
+such data &mdash;
+the required `/entry/data/energy` becomes 2-D but `Horace` expects (and reshapes) this
+data to be 1-D.
+
+One symptom of this incompatibility is excessive memory usage.
+For the 13500 BIFROST detector elements, with energy transfer binned into 103 bins,
+in an early conversion step `Horace` requires a 13500 &times; 104 &times; 13500 array
+of double values, and while &sim; 141 GB is not an insurmountable value it's also
+not necessary.
+
+In testing, moving to a machine with 256 GB of memory was not sufficient for the
+conversion to proceed. And it seems likely there are more incompatible assumptions
+made about the content of the data for `Horace` to successfully produce an `SQW` object
+from the '`BIFROST`-`NXspe`' files.
+
+
+## Decision
+It is now possible to make `BIFROST` data conform to the `NXspe` standard published by
+the NeXus Foundation, but community software that _reads_ `NXspe` is likely to have
+made similar assumptions about the shape of required data as `Horace`.
+So the utility of `NXspe` as a common data format is likely limited.
+
+_Producing_ `NXspe` may still be useful, but it can not replace direct output of
+`SQW` data files.
+
+&therefore; Relegate `NXspe` to lesser-supported output formats.
+
+## Consequences
+A fully-fledged `SQW` output method is still required, which will still pose the same
+problems of construction and maintainability.

--- a/docs/developer/adr/0001-relegate-nxspe-support.md
+++ b/docs/developer/adr/0001-relegate-nxspe-support.md
@@ -1,7 +1,7 @@
 # ADR 0001: Relagate NXspe support
 
-- Status:
-- Deciders:
+- Status: accepted
+- Deciders: Greg, Jan-Lukas
 - Date: 2024-10
 
 ## Context

--- a/docs/developer/architecture-decision-records.md
+++ b/docs/developer/architecture-decision-records.md
@@ -1,0 +1,10 @@
+# Architecture Decision Records
+
+```{toctree}
+---
+maxdepth: 1
+glob: true
+---
+
+adr/*
+```

--- a/docs/developer/index.md
+++ b/docs/developer/index.md
@@ -13,4 +13,6 @@ maxdepth: 2
 getting-started
 coding-conventions
 dependency-management
+architecture-decision-records
 ```
+

--- a/src/ess/spectroscopy/indirect/__init__.py
+++ b/src/ess/spectroscopy/indirect/__init__.py
@@ -1,9 +1,10 @@
 # SPDX-License-Identifier: BSD-3-Clause
 # Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
 
-from .workflow import bifrost, bifrost_single
+from .workflow import bifrost, bifrost_single, bifrost_to_nxspe
 
 __all__ = (
     "bifrost",
     "bifrost_single",
+    "bifrost_to_nxspe",
 )

--- a/src/ess/spectroscopy/indirect/conservation.py
+++ b/src/ess/spectroscopy/indirect/conservation.py
@@ -5,8 +5,10 @@ from scipp import vector
 
 from ..types import (
     EnergyTransfer,
+    FinalEnergy,
     FinalWavenumber,
     FinalWavevector,
+    IncidentEnergy,
     IncidentWavenumber,
     IncidentWavevector,
     LabMomentumTransfer,
@@ -123,6 +125,12 @@ def energy(ki: IncidentWavenumber, kf: FinalWavenumber) -> EnergyTransfer:
     return hbar * hbar * (ki * ki - kf * kf) / 2 / neutron_mass
 
 
+def energy_transfer(
+    incident_energy: IncidentEnergy, final_energy: FinalEnergy
+) -> EnergyTransfer:
+    return incident_energy - final_energy
+
+
 providers = (
     *ki_providers,
     *kf_providers,
@@ -135,4 +143,5 @@ providers = (
     sample_table_momentum_y,
     sample_table_momentum_z,
     energy,
+    energy_transfer,
 )

--- a/src/ess/spectroscopy/indirect/io.py
+++ b/src/ess/spectroscopy/indirect/io.py
@@ -129,9 +129,10 @@ def _to_one_nxspe(events: DataArray, filename: str, progress):
     polar_width = sc.full(sizes=polar.sizes, unit='deg', value=0.1)
     distance = sc.full(sizes=polar.sizes, unit='m', value=3.0, dtype=polar.dtype)
     data = observations.data
-    error = 0 * observations.data.values
     if observations.data.variances is not None:
         error = numpy.sqrt(observations.data.variances)
+    else:
+        error = 0 * observations.data.values
     energy_transfer = observations.coords['energy_transfer']
     incident_energy = observations.coords['incident_energy']
     final_energy = observations.coords['final_energy']

--- a/src/ess/spectroscopy/indirect/io.py
+++ b/src/ess/spectroscopy/indirect/io.py
@@ -1,0 +1,191 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2024 Scipp contributors (https://github.com/scipp)
+
+from __future__ import annotations
+
+import h5py
+import numpy
+import scippnexus
+from scipp import DataArray
+
+from ..types import NormWavelengthEvents, NXspeFileName, NXspeFileNames
+
+
+def to_nxspe(events: NormWavelengthEvents, base: NXspeFileName) -> NXspeFileNames:
+    """Take events, which have been binned in incident wavelength and have monitor
+    counts per bin, and output one NXspe file per setting
+
+    Parameters
+    ----------
+    events: scipp.DataArray
+        The events binned in (setting, event_id, incident_wavelength) with
+        at least 'monitor', 'a3', and 'theta' bin coordinates.
+        The events and the bins must also have an 'incident_wavelength' coordinate.
+    base: str | Path
+        The filename base used to produce each NXspe filename.
+
+    Returns
+    -------
+    :
+        The list of filenames containing the NXspe data. If there are N settings in the
+        input DataArray, N filenames are returned. The names are of the form
+            {base}_{i+1:0{ceil(log10(N+1))}d}.nxspe
+    """
+    from pathlib import Path
+
+    from tqdm import tqdm
+
+    dim = 'setting'
+    length = len(str(events.sizes[dim] + 1))
+    files = []
+    if not isinstance(base, Path):
+        base = Path(base)
+    parent = base.parent
+    if not parent.exists():
+        parent.mkdir(parents=True)
+
+    progress = tqdm(range(events.sizes[dim]))
+    for i in progress:
+        ev = events[dim, i]
+        fn = str(base) + '_' + f'{i+1}'.rjust(length, '0') + '.nxspe'
+        files.append(NXspeFileName(fn))
+        _to_one_nxspe(ev, fn, progress)
+    return NXspeFileNames(files)
+
+
+def _make_group(group: h5py.Group) -> scippnexus.Group:
+    return scippnexus.Group(group, definitions=scippnexus.base_definitions())
+
+
+def _lambda_to_ei(incident_wavelength):
+    from scipp.constants import Planck, neutron_mass
+
+    return ((Planck / incident_wavelength) ** 2 / neutron_mass / 2).to(unit='meV')
+
+
+def _ei_ef_to_en(incident_energy, final_energy):
+    return incident_energy - final_energy
+
+
+def _to_one_nxspe(events: DataArray, filename: str, progress):
+    """Use scippnexus to create the NXspe file"""
+    from scipp import full, scalar, sqrt
+    from scippnexus import (
+        NXcollection,
+        NXdata,
+        NXentry,
+        NXfermi_chopper,
+        NXinstrument,
+        NXsample,
+    )
+
+    observations = events.copy()
+    ef = events.coords['final_energy']
+    observations *= sqrt(events.bins.coords['incident_energy'] / ef)
+
+    # Adding null events requires replicating all coordinates of real events.
+    # We don't necessarily use all present event coordinates, so remove any we won't use
+    targets = [
+        'energy_transfer',
+        'incident_energy',
+        'incident_wavelength',
+        'final_energy',
+    ]
+    for coord in [x for x in events.bins.coords if x not in targets]:
+        del observations.bins.coords[coord]
+    # And provide a means to calculate the rest from bin (not event) information
+    # we are sure incident_wavelength is a bin coordinate already, so can skip it.
+    graph = {
+        'incident_energy': _lambda_to_ei,
+        'energy_transfer': _ei_ef_to_en,
+    }
+    # # Adding zero-weight observations, i.e., null events, works now, but involves
+    # # a memory-copy of the data array and its bin structure. Since it isn't strictly
+    # # necessary for exporting NXspe, it can be skipped for now.
+    # observations = add_null_observations(observations, targets, graph)
+
+    # combine the per bin intensities and normalize by monitor counts
+    # Note, applying this normalization to the _events_ would require splitting
+    # the bin monitor counts between the bin events.
+    normalize_by = events.coords['monitor']  # .broadcast(sizes=observations.sizes)
+    if normalize_by.variances is not None:
+        # we need to ignore the monitor uncertainty for the time being
+        normalize_by = normalize_by.copy()
+        normalize_by.variances = None
+
+    observations = observations.hist().transform_coords(targets, graph=graph)
+
+    if observations.variances is None:
+        observations.variances = observations.values  # correct for counting statistics
+        observations.variances[observations.values == 0] = 1
+    if observations.data.variances is not None:
+        observations.data.variances[observations.data.variances == 0] = 1
+    # the transform_coords above renamed the 'incident_wavelength' dimension
+    # to 'energy_transfer' ... so we need to do the same to normalize_by or else
+    # scipp tries to broadcast when it doesn't need to.
+    observations.data = observations.data / normalize_by.rename_dims(
+        incident_wavelength='energy_transfer'
+    )
+
+    psi = observations.coords['a3']
+    polar = observations.coords['theta']
+    azimuthal = 0 * polar  # all detectors are in the horizontal plane
+    azimuthal_width = azimuthal + scalar(2.0, unit='degree')
+    polar_width = azimuthal + scalar(0.1, unit='degree')
+    distance = full(sizes=polar.sizes, unit='m', value=3.0, dtype=polar.dtype)
+    data = observations.data
+    error = 0 * observations.data.values
+    if observations.data.variances is not None:
+        error = numpy.sqrt(observations.data.variances)
+    energy_transfer = observations.coords['energy_transfer']
+    incident_energy = observations.coords['incident_energy']
+    final_energy = observations.coords['final_energy']
+
+    with h5py.File(filename, mode='w') as f:
+        # make / in the file
+        root = _make_group(f)
+        # it _must_ contain an NXentry group, called [anything which is allowed]?
+        # with two fields and five subgroups required
+        entry = root.create_class('entry', NXentry)
+        # the name of  the author program
+        entry.create_field('program_name', scalar('essspectroscopy'))
+        # and the NXDL schema information -- currently version 3.1
+        definition = entry.create_field('definition', scalar('NXSPE'))
+        definition.attrs['version'] = '3.1'
+
+        # the entry group also contains five subgroups
+
+        # the NXcollection group must contain three fields
+        nxinfo = entry.create_class('NXSPE_info', NXcollection)
+        nxinfo.create_field('fixed_energy', final_energy)
+        nxinfo.create_field('ki_over_kf_scaling', scalar(True))
+        nxinfo.create_field('psi', psi)
+
+        # the NXdata group has 8 required fields
+        nxdata = entry.create_class('data', NXdata)
+        nxdata.create_field('azimuthal', azimuthal)
+        nxdata.create_field('azimuthal_width', azimuthal_width)
+        nxdata.create_field('polar', polar)
+        nxdata.create_field('polar_width', polar_width)
+        nxdata.create_field('distance', distance)
+        nxdata.create_field('data', data)
+        nxdata.create_field('error', error)
+        nxdata.create_field('energy', energy_transfer)
+        # Actually more useful extensions to NXspe for an instrument like BIFROST
+        nxdata.create_field('final_energy', final_energy)
+        nxdata.create_field('incident_energy', incident_energy)
+
+        # the NXinstrument group has one required field and one required group
+        instrument = entry.create_class('instrument', NXinstrument)
+        instrument.create_field('name', scalar('SIMBIFROST'))
+        fermi = instrument.create_class('fermi_chopper', NXfermi_chopper)
+        fermi.create_field('energy', scalar(numpy.nan, unit='meV'))
+
+        # and the NXsample group has three required fields
+        sample = entry.create_class('sample', NXsample)
+        sample.create_field('rotation_angle', psi)
+        sample.create_field('seblock', scalar(""))
+        sample.create_field('temperature', scalar(numpy.nan, unit='K'))
+
+
+providers = (to_nxspe,)

--- a/src/ess/spectroscopy/indirect/io.py
+++ b/src/ess/spectroscopy/indirect/io.py
@@ -107,11 +107,8 @@ def _to_one_nxspe(events: DataArray, filename: str, progress):
     # combine the per bin intensities and normalize by monitor counts
     # Note, applying this normalization to the _events_ would require splitting
     # the bin monitor counts between the bin events.
-    normalize_by = events.coords['monitor']  # .broadcast(sizes=observations.sizes)
-    if normalize_by.variances is not None:
-        # we need to ignore the monitor uncertainty for the time being
-        normalize_by = normalize_by.copy()
-        normalize_by.variances = None
+    # we need to ignore the monitor uncertainty for the time being
+    normalize_by = sc.values(events.coords['monitor'])
 
     observations = observations.hist().transform_coords(targets, graph=graph)
 

--- a/src/ess/spectroscopy/indirect/io.py
+++ b/src/ess/spectroscopy/indirect/io.py
@@ -124,9 +124,9 @@ def _to_one_nxspe(events: DataArray, filename: str, progress):
 
     psi = observations.coords['a3']
     polar = observations.coords['theta']
-    azimuthal = 0 * polar  # all detectors are in the horizontal plane
-    azimuthal_width = azimuthal + sc.scalar(2.0, unit='degree')
-    polar_width = azimuthal + sc.scalar(0.1, unit='degree')
+    azimuthal = sc.zeros(sizes=polar.sizes, unit='deg', dtype=polar.dtype)
+    azimuthal_width = sc.full(sizes=polar.sizes, unit='deg', value=2.0)
+    polar_width = sc.full(sizes=polar.sizes, unit='deg', value=0.1)
     distance = sc.full(sizes=polar.sizes, unit='m', value=3.0, dtype=polar.dtype)
     data = observations.data
     error = 0 * observations.data.values

--- a/src/ess/spectroscopy/indirect/workflow.py
+++ b/src/ess/spectroscopy/indirect/workflow.py
@@ -8,7 +8,6 @@ from scipp import Variable
 
 from ..types import NeXusFileName, NormWavelengthEvents, NXspeFileName
 
-# PIXEL_NAME = 'event_id'
 PIXEL_NAME = 'detector_number'
 
 

--- a/src/ess/spectroscopy/indirect/workflow.py
+++ b/src/ess/spectroscopy/indirect/workflow.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 from loguru import logger
 from scipp import Variable
 
-from ..types import NeXusFileName, NormWavelengthEvents
+from ..types import NeXusFileName, NormWavelengthEvents, NXspeFileName
+
+# PIXEL_NAME = 'event_id'
+PIXEL_NAME = 'detector_number'
 
 
 def _load_all(group, obj_type):
@@ -158,8 +161,8 @@ def detector_per_pixel(triplets: dict) -> dict[int, str]:
 
 
 def combine_analyzers(analyzers: dict, triplets: dict):
-    """Combine needed analyzer properties into a single array, duplicating information,
-    to have per-pixel data
+    """Combine needed analyzer properties into a single array,
+    duplicating information, to have per-pixel data
 
     BIFROST has 45 analyzers and 45 triplet detectors, each with some number of pixels,
     N. Calculations for the properties of neutrons which make it to each detector pixel
@@ -186,8 +189,7 @@ def combine_analyzers(analyzers: dict, triplets: dict):
     Returns
     -------
     :
-        A single array with 'event_id' pixel dimension and the
-        per-pixel analyzer information
+        A single array with pixel dimension and the per-pixel analyzer information
     """
     from scipp import Dataset, array, concat
     from scippnexus import compute_positions
@@ -202,8 +204,8 @@ def combine_analyzers(analyzers: dict, triplets: dict):
 
     p2a = {k: extracted[d2a[v]] for k, v in p2d.items()}
     pixels = sorted(p2a)
-    data = concat([p2a[p] for p in pixels], dim='event_id')
-    data['event_id'] = array(values=pixels, dims=['event_id'], unit=None)
+    data = concat([p2a[p] for p in pixels], dim=PIXEL_NAME)
+    data[PIXEL_NAME] = array(values=pixels, dims=[PIXEL_NAME], unit=None)
     return data
 
 
@@ -226,19 +228,18 @@ def combine_detectors(triplets: dict):
     Returns
     -------
     :
-        A single array with 'event_id' pixel dimension and the
-        per-pixel center of mass position
+        A single array with pixel dimension and the per-pixel center of mass position
     """
     from scipp import Dataset, concat, sort
 
     def extract(obj):
         pixels = obj['data'].coords['detector_number']
         midpoints = obj['data'].coords['position']
-        return Dataset(data={'event_id': pixels, 'position': midpoints})
+        return Dataset(data={PIXEL_NAME: pixels, 'position': midpoints})
 
     data = concat([extract(v) for v in triplets.values()], dim='arm')
-    data = Dataset({k: v.flatten(to='event_id') for k, v in data.items()})
-    return sort(data, data['event_id'].data)
+    data = Dataset({k: v.flatten(to=PIXEL_NAME) for k, v in data.items()})
+    return sort(data, data[PIXEL_NAME].data)
 
 
 def find_sample_detector_flight_time(sample, analyzers, detector_positions):
@@ -286,7 +287,7 @@ def get_triplet_events(triplets):
     """
     from scipp import concat, sort
 
-    events = concat([x['data'] for x in triplets], dim='arm').flatten(to='event_id')
+    events = concat([x['data'] for x in triplets], dim='arm').flatten(to=PIXEL_NAME)
     events = sort(events, events.coords['detector_number'])
     return events
 
@@ -531,6 +532,17 @@ def add_wavelength_axes(ki_params, kf_params, events, monitor, monitor_name):
     return events, wavelength_monitor
 
 
+def get_geometric_a4(kf_params):
+    from sciline import Pipeline
+
+    from ..types import DetectorGeometricA4
+    from .kf import providers
+
+    pipeline = Pipeline(providers, params=kf_params)
+    geometric_a4 = pipeline.compute(DetectorGeometricA4)
+    return geometric_a4
+
+
 def normalise_wavelength_events(ki_params, kf_params, events, monitor):
     from sciline import Pipeline
 
@@ -720,6 +732,8 @@ def one_setting(
     events.bins.coords['energy_transfer'] = en.to(unit='meV')
     events.bins.coords['incident_energy'] = ei
     events.coords['final_energy'] = ef
+
+    events.coords['theta'] = get_geometric_a4(kf_params)
 
     if 'a3' in triplet_events.coords:
         # this _should_ be one (a3, a4) setting,
@@ -1006,3 +1020,31 @@ def bifrost_single(
         data['logs'] = logs
 
     return data
+
+
+def bifrost_to_nxspe(
+    *,
+    output: NXspeFileName,
+    filename: NeXusFileName | None = None,
+    events: NormWavelengthEvents | None = None,
+    **kwargs,
+):
+    from sciline import Pipeline
+
+    from ..types import NXspeFileNames
+    from .io import providers as io_providers
+
+    if filename is None and events is None:
+        raise ValueError("Provide events, or filename to read and reduce file")
+    if events is None:
+        reduced = bifrost(filename, **kwargs)
+        events = reduced['norm_events']
+
+    pipeline = Pipeline(
+        providers=io_providers,
+        params={
+            NXspeFileName: output,
+            NormWavelengthEvents: events,
+        },
+    )
+    return pipeline.compute(NXspeFileNames)


### PR DESCRIPTION
`NXspe` output for BIFROST is not suitable for ingestion by `Horace` due to per-detector-element energy-transfer binning.
An ADR is added explaining this limitation and concluding that support for `NXspe` should be demoted is included.

> [!TIP]
> Thinking about it now, spliting each measured `setting` into 9 files, one per tube-arc, _might_ be an acceptable trade-off if no alternative is found.


It is not clear whether _other_ analysis tools will handle the BIFROST `NXspe` files better; and the conversion to histogram _observations_ may be a useful template for output to `SQW`.
Therefore the current implementation of `NXspe` output is included in this PR.