### PR TITLE
Do not use removed upstream type vars

### DIFF
--- a/src/ess/bifrost/types.py
+++ b/src/ess/bifrost/types.py
@@ -9,18 +9,10 @@ This module supplements :mod:`ess.spectroscopy.types` with BIFROST-specific type
 import sciline
 import scipp as sc
 
-from ess.reduce.nexus import types as reduce_t
 from ess.spectroscopy.types import RunType
 
 
 class ArcNumber(sciline.Scope[RunType, sc.Variable], sc.Variable): ...
-
-
-# See https://github.com/scipp/essreduce/issues/105 about monitor names
-FrameMonitor0 = reduce_t.Monitor1
-FrameMonitor1 = reduce_t.Monitor2
-FrameMonitor2 = reduce_t.Monitor3
-FrameMonitor3 = reduce_t.Monitor4
 
 
 class McStasDetectorData(sciline.Scope[RunType, sc.DataArray], sc.DataArray): ...

--- a/src/ess/bifrost/workflow.py
+++ b/src/ess/bifrost/workflow.py
@@ -15,6 +15,10 @@ from ess.spectroscopy.indirect.normalization import providers as normalisation_p
 from ess.spectroscopy.indirect.time_of_flight import TofWorkflow
 from ess.spectroscopy.types import (
     DataGroupedByRotation,
+    FrameMonitor0,
+    FrameMonitor1,
+    FrameMonitor2,
+    FrameMonitor3,
     NeXusDetectorName,
     NeXusMonitorName,
     PulsePeriod,
@@ -25,12 +29,6 @@ from .cutting import providers as cutting_providers
 from .detector import merge_triplets
 from .detector import providers as detector_providers
 from .io import mcstas, nexus
-from .types import (
-    FrameMonitor0,
-    FrameMonitor1,
-    FrameMonitor2,
-    FrameMonitor3,
-)
 
 
 def simulation_default_parameters() -> dict[type, Any]:

--- a/src/ess/spectroscopy/types.py
+++ b/src/ess/spectroscopy/types.py
@@ -30,20 +30,25 @@ NeXusMonitorName = reduce_t.NeXusName
 NeXusTransformation = reduce_t.NeXusTransformation
 Position = reduce_t.Position
 PreopenNeXusFile = reduce_t.PreopenNeXusFile
+
+
 SampleRun = reduce_t.SampleRun
+VanadiumRun = reduce_t.VanadiumRun
+
+FrameMonitor0 = reduce_t.FrameMonitor0
+FrameMonitor1 = reduce_t.FrameMonitor1
+FrameMonitor2 = reduce_t.FrameMonitor2
+FrameMonitor3 = reduce_t.FrameMonitor3
 
 # Type vars
 
-# Include BackgroundRun because a single constraint is not allowed.
-# We will eventually have more than one...
-RunType = TypeVar("RunType", SampleRun, reduce_t.BackgroundRun)
-# Monitor types include all monitors used by instrument packages.
+RunType = TypeVar("RunType", SampleRun, VanadiumRun)
 MonitorType = TypeVar(
     "MonitorType",
-    reduce_t.Monitor1,
-    reduce_t.Monitor2,
-    reduce_t.Monitor3,
-    reduce_t.Monitor4,
+    FrameMonitor0,
+    FrameMonitor1,
+    FrameMonitor2,
+    FrameMonitor3,
 )
 
 # Time-of-flight types

--- a/tests/bifrost/workflow_test.py
+++ b/tests/bifrost/workflow_test.py
@@ -12,11 +12,11 @@ from ess.bifrost.data import (
     simulated_elastic_incoherent_with_phonon,
     tof_lookup_table_simulation,
 )
-from ess.bifrost.types import FrameMonitor3
 from ess.spectroscopy.types import (
     DetectorData,
     EnergyData,
     Filename,
+    FrameMonitor3,
     MonitorData,
     NeXusDetectorName,
     SampleRun,


### PR DESCRIPTION
ESSreduce lost some monitor type vars (unreleased). This PR should fix the nightly builds.