### PR TITLE
[Ref] detector merge, angle split order

### DIFF
--- a/src/ess/bifrost/workflow.py
+++ b/src/ess/bifrost/workflow.py
@@ -14,7 +14,7 @@ from ess.spectroscopy.indirect.ki import providers as ki_providers
 from ess.spectroscopy.indirect.normalization import providers as normalisation_providers
 from ess.spectroscopy.indirect.time_of_flight import TofWorkflow
 from ess.spectroscopy.types import (
-    DataGroupedByRotation,
+    DetectorData,
     FrameMonitor0,
     FrameMonitor1,
     FrameMonitor2,
@@ -86,8 +86,8 @@ def BifrostSimulationWorkflow(
     for key, val in simulation_default_parameters().items():
         workflow[key] = val
 
-    workflow[DataGroupedByRotation[SampleRun]] = (
-        workflow[DataGroupedByRotation[SampleRun]]
+    workflow[DetectorData[SampleRun]] = (
+        workflow[DetectorData[SampleRun]]
         .map(_make_detector_name_mapping(detector_names))
         .reduce(func=merge_triplets)
     )


### PR DESCRIPTION
If a detector has no intensity within a measurement period the current `group_by_rotation` implementation 'misses' the null observation. This will cause normalization issues later if not correctly accounted for, but immediately prevents `merge_triplets` from succeeding in the case of different 'misses' per detector.

This PR reorders the calls to `merge_triplet` and `group_by_rotation`.

The possibility of 'missing' an observation remains, but would require _all_ detectors to record no events.

> [!WARNING]
> One test, `test_simulation_workflow_produces_the_same_data_as_before`, now fails; which seems like it should be expected and the reported failure looks acceptable to me
> E           AssertionError: 
E           Not equal to tolerance rtol=1e-07, atol=0
E           when comparing values
E           Mismatched elements: 1288287 / 1289438 (99.9%)
E           Max absolute difference among violations: 1.56774558e-08
E           Max relative difference among violations: 1.77814347
E            ACTUAL: array([ 0.008106,  0.021405, -0.01404 , ...,  0.046532,  0.054073,
E                   0.039995])
E            DESIRED: array([ 0.008106,  0.021405, -0.01404 , ...,  0.046532,  0.054073,
E                   0.039995])
E           in values
