### PR TITLE
Replace Frame0 with Psd Monitor

### DIFF
--- a/docs/user-guide/bifrost/bifrost-reduction.ipynb
+++ b/docs/user-guide/bifrost/bifrost-reduction.ipynb
@@ -27,6 +27,7 @@
     "    simulated_elastic_incoherent_with_phonon,\n",
     "    tof_lookup_table_simulation\n",
     ")\n",
+    "from ess.bifrost.types import *\n",
     "from ess.spectroscopy.types import *"
    ]
   },

--- a/src/ess/bifrost/single_crystal/workflow.py
+++ b/src/ess/bifrost/single_crystal/workflow.py
@@ -4,14 +4,15 @@
 
 import sciline
 
-from ess.reduce import time_of_flight as reduce_time_of_flight
-from ess.spectroscopy.indirect.time_of_flight import TofWorkflow
-from ess.spectroscopy.types import (
+from ess.bifrost.types import (
     FrameMonitor1,
     FrameMonitor2,
     FrameMonitor3,
+    PsdMonitor,
     SampleRun,
 )
+from ess.reduce import time_of_flight as reduce_time_of_flight
+from ess.spectroscopy.indirect.time_of_flight import TofWorkflow
 
 from ..cutting import group_by_rotation
 from ..io import nexus
@@ -32,7 +33,7 @@ _PROVIDERS = (
 def BifrostBraggPeakMonitorWorkflow() -> sciline.Pipeline:
     workflow = TofWorkflow(
         run_types=(SampleRun,),
-        monitor_types=(FrameMonitor1, FrameMonitor2, FrameMonitor3),
+        monitor_types=(FrameMonitor1, FrameMonitor2, FrameMonitor3, PsdMonitor),
     )
     # Use the vanilla implementation instead of the indirect geometry one:
     workflow.insert(reduce_time_of_flight.eto_to_tof.detector_time_of_flight_data)

--- a/src/ess/bifrost/types.py
+++ b/src/ess/bifrost/types.py
@@ -6,10 +6,21 @@
 This module supplements :mod:`ess.spectroscopy.types` with BIFROST-specific types.
 """
 
+from typing import NewType
+
 import sciline
 import scipp as sc
 
+from ess.reduce.nexus import types as reduce_t
 from ess.spectroscopy.types import RunType
+
+SampleRun = reduce_t.SampleRun
+VanadiumRun = reduce_t.VanadiumRun
+
+FrameMonitor1 = reduce_t.FrameMonitor1
+FrameMonitor2 = reduce_t.FrameMonitor2
+FrameMonitor3 = reduce_t.FrameMonitor3
+PsdMonitor = NewType('PsdMonitor', int)
 
 
 class ArcNumber(sciline.Scope[RunType, sc.Variable], sc.Variable): ...

--- a/src/ess/bifrost/workflow.py
+++ b/src/ess/bifrost/workflow.py
@@ -17,21 +17,23 @@ from ess.spectroscopy.indirect.time_of_flight import TofWorkflow
 from ess.spectroscopy.types import (
     BeamlineWithSpectrometerCoords,
     DetectorData,
-    FrameMonitor0,
-    FrameMonitor1,
-    FrameMonitor2,
-    FrameMonitor3,
     NeXusData,
     NeXusDetectorName,
     NeXusMonitorName,
     PulsePeriod,
-    SampleRun,
 )
 
 from .cutting import providers as cutting_providers
 from .detector import merge_triplets
 from .detector import providers as detector_providers
 from .io import mcstas, nexus
+from .types import (
+    FrameMonitor1,
+    FrameMonitor2,
+    FrameMonitor3,
+    PsdMonitor,
+    SampleRun,
+)
 
 
 def simulation_default_parameters() -> dict[type, Any]:
@@ -40,6 +42,7 @@ def simulation_default_parameters() -> dict[type, Any]:
         NeXusMonitorName[FrameMonitor1]: '090_frame_1',
         NeXusMonitorName[FrameMonitor2]: '097_frame_2',
         NeXusMonitorName[FrameMonitor3]: '110_frame_3',
+        NeXusMonitorName[PsdMonitor]: '111_psd0_monitor',
         PulsePeriod: 1.0 / sc.scalar(14.0, unit="Hz"),
     }
 
@@ -73,7 +76,7 @@ def BifrostSimulationWorkflow(
     """
     workflow = TofWorkflow(
         run_types=(SampleRun,),
-        monitor_types=(FrameMonitor0, FrameMonitor1, FrameMonitor2, FrameMonitor3),
+        monitor_types=(FrameMonitor1, FrameMonitor2, FrameMonitor3),
     )
     for provider in _SIMULATION_PROVIDERS:
         workflow.insert(provider)
@@ -95,7 +98,7 @@ def BifrostWorkflow(
     """Data reduction workflow for BIFROST."""
     workflow = TofWorkflow(
         run_types=(SampleRun,),
-        monitor_types=(FrameMonitor0, FrameMonitor1, FrameMonitor2, FrameMonitor3),
+        monitor_types=(FrameMonitor1, FrameMonitor2, FrameMonitor3, PsdMonitor),
     )
     # TODO change to use non-simulation providers
     for provider in _SIMULATION_PROVIDERS:

--- a/src/ess/spectroscopy/types.py
+++ b/src/ess/spectroscopy/types.py
@@ -3,7 +3,7 @@
 
 """Domain types for spectroscopy."""
 
-from typing import Any, NewType, TypeVar
+from typing import Any, NewType
 
 import sciline
 import scipp as sc
@@ -20,6 +20,7 @@ DetectorPositionOffset = reduce_t.DetectorPositionOffset
 GravityVector = reduce_t.GravityVector
 Filename = reduce_t.Filename
 MonitorData = reduce_t.MonitorData
+MonitorType = reduce_t.MonitorType
 NeXusClass = reduce_t.NeXusClass
 NeXusComponentLocationSpec = reduce_t.NeXusComponentLocationSpec
 NeXusComponent = reduce_t.NeXusComponent
@@ -30,26 +31,8 @@ NeXusMonitorName = reduce_t.NeXusName
 NeXusTransformation = reduce_t.NeXusTransformation
 Position = reduce_t.Position
 PreopenNeXusFile = reduce_t.PreopenNeXusFile
+RunType = reduce_t.RunType
 
-
-SampleRun = reduce_t.SampleRun
-VanadiumRun = reduce_t.VanadiumRun
-
-FrameMonitor0 = reduce_t.FrameMonitor0
-FrameMonitor1 = reduce_t.FrameMonitor1
-FrameMonitor2 = reduce_t.FrameMonitor2
-FrameMonitor3 = reduce_t.FrameMonitor3
-
-# Type vars
-
-RunType = TypeVar("RunType", SampleRun, VanadiumRun)
-MonitorType = TypeVar(
-    "MonitorType",
-    FrameMonitor0,
-    FrameMonitor1,
-    FrameMonitor2,
-    FrameMonitor3,
-)
 
 # Time-of-flight types
 

--- a/tests/bifrost/workflow_test.py
+++ b/tests/bifrost/workflow_test.py
@@ -12,14 +12,13 @@ from ess.bifrost.data import (
     simulated_elastic_incoherent_with_phonon,
     tof_lookup_table_simulation,
 )
+from ess.bifrost.types import FrameMonitor3, SampleRun
 from ess.spectroscopy.types import (
     DetectorData,
     EnergyData,
     Filename,
-    FrameMonitor3,
     MonitorData,
     NeXusDetectorName,
-    SampleRun,
     TimeOfFlightLookupTable,
     WavelengthMonitor,
 )


### PR DESCRIPTION
Bifrost does not actually have a frame monitor 0. But it does have a PSD monitor. This PR adjusts the domain types and names accordingly. Unfortunately, the current simulation files don't reflect this. But we don't use the monitors currently anyway.

But this should fix an nightly test, see https://git.esss.dk/dmsc-nightly/dmsc-nightly/-/issues/50 and https://git.esss.dk/dmsc-nightly/dmsc-nightly/-/merge_requests/153