### PR TITLE
Add redirects for new documentation URLs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -277,3 +277,9 @@ linkcheck_ignore = [
     r'https?://jira\.ess\.eu',
     r'https?://dx\.doi\.org/',
 ]
+
+# -- Redirect to new docs --------------------------------------------------
+
+redirects = {
+    "*": "https://scipp.github.io/ess/spectroscopy/$source.html",
+}


### PR DESCRIPTION
It should be merged after we publish essspectroscopy docs in the mono repo I guess...?